### PR TITLE
fix 500 Internal server error

### DIFF
--- a/cmd/gaiko/server.go
+++ b/cmd/gaiko/server.go
@@ -115,7 +115,9 @@ func runServer(c *cli.Context) error {
 
 		args := flags.NewArguments(c)
 		// override the proof writer to get the proof & return as response
-		args.ProofWriter = bytesBufferPool.Get().(*bytes.Buffer)
+		buf := bytesBufferPool.Get().(*bytes.Buffer)
+		buf.Reset()
+		args.ProofWriter = buf
 		defer bytesBufferPool.Put(args.ProofWriter)
 		args.WitnessReader = r.Body
 		sgxProver := prover.NewSGXProver(args)


### PR DESCRIPTION
or("Failed to read error response: 500 Internal Server Error"))
2025-05-08T03:50:53.274390Z ERROR sgx_prover::remote_prover: Request failed with status: 500 Internal Server Error
2025-05-08T03:50:53.275170Z ERROR raiko_reqactor::backend: Actor Backend failed to prove {"Aggregation":{"proof_type":"SgxGeth","block_numbers":[24096]}}: failed to generate aggregation proof: Guest(GuestError("Failed to read error response: 500 Internal Server Error"))
2025-05-08T03:52:15.990065Z ERROR sgx_prover::remote_prover: Request failed with status: 500 Internal Server Error
2025-05-08T03:52:15.992051Z ERROR raiko_reqactor::backend: Actor Backend failed to prove {"BatchProof":{"guest_input_key":{"chain_id":167001,"batch_id":24097,"l1_inclusion_height":168526},"proof_type":"SgxGeth","prover_address":"0x8C0AD6e094DeE392b926d4c543Edd63ba26C0692"}}: failed to generate batch proof: Guest(GuestError("Failed to read error response: 500 Internal Server Error"))
2025-05-08T03:52:21.403672Z ERROR sgx_prover::remote_prover: Request failed with status: 500 Internal Server Error
2025-05-08T03:52:21.405142Z ERROR raiko_reqactor::backend: Actor Backend failed to prove {"Aggregation":{"proof_type":"SgxGeth","block_numbers":[24097]}}: failed to generate aggregation proof: Guest(GuestError("Failed to read error response: 500 Internal Server Error"))
2025-05-08T03:53:41.738293Z ERROR sgx_prover::remote_prover: Request failed with status: 500 Internal Server Error

