### PR TITLE
chore(docs): Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,5 +87,5 @@ GLOBAL OPTIONS:
 
 
 COPYRIGHT:
-   Copyright 2025-2025 The Gaiko Authors
+   Copyright 2025 The Gaiko Authors
 ```


### PR DESCRIPTION
removed the double year 2025 from the license