### PR TITLE
fix: bind chain spec name in witness validation

### DIFF
--- a/internal/witness/chain_spec.go
+++ b/internal/witness/chain_spec.go
@@ -34,6 +34,9 @@ func (s SupportedChainSpecs) verifyChainSpec(other *ChainSpec) error {
 		if chainSpec.ChainID != other.ChainID {
 			continue
 		}
+		if chainSpec.Name != other.Name {
+			return errors.New("unexpected name")
+		}
 		if chainSpec.MaxSpecID != other.MaxSpecID {
 			return errors.New("unexpected max_spec_id")
 		}

--- a/internal/witness/chain_spec_test.go
+++ b/internal/witness/chain_spec_test.go
@@ -54,3 +54,20 @@ func TestTransitionChainConfig(t *testing.T) {
 		require.Nil(t, chainConfig.ShastaTime)
 	})
 }
+
+func TestVerifyChainSpecRejectsNameMismatch(t *testing.T) {
+	var mainnetSpec *ChainSpec
+	for _, chainSpec := range defaultSupportedChainSpecs {
+		if chainSpec.Name == TaikoMainnetNetwork {
+			mainnetSpec = chainSpec
+			break
+		}
+	}
+	require.NotNil(t, mainnetSpec)
+
+	mismatchedSpec := *mainnetSpec
+	mismatchedSpec.Name = TaikoDevNetwork
+
+	err := defaultSupportedChainSpecs.verifyChainSpec(&mismatchedSpec)
+	require.EqualError(t, err, "unexpected name")
+}


### PR DESCRIPTION
## Summary
- Reject chain specs whose chain ID matches a known network but whose name differs from the embedded spec.
- Add a regression test for mainnet chain ID with a devnet name.

## Tests
- go test ./internal/witness -count=1